### PR TITLE
Improves the way we register NICs

### DIFF
--- a/register-system.yaml
+++ b/register-system.yaml
@@ -40,6 +40,10 @@
       shell: ipmitool lan print |grep "IP Address" | grep -v Source | cut -d ':' -f 2
       register: ipmi_addr
 
+    - name: "Get physical network interfaces"
+      command: find /sys/class/net -type l -not -lname '*virtual*' -printf '%f\n'
+      register: physical_interfaces
+
     - name: "Calcuate rack and rackpos"
       set_fact:
         rack: "{{ parsed_address[-2] }}"
@@ -122,7 +126,7 @@
         state: present
       delegate_to: 127.0.0.1
 
-    - name: "Create network interfaces"
+    - name: "Create physical network interfaces"
       netbox.netbox.netbox_device_interface:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
@@ -136,7 +140,23 @@
         interface: >-
           {{ hostvars[inventory_hostname]["ansible_{}".format(item.replace('-', '_'))] }}
       delegate_to: 127.0.0.1
-      loop: "{{ ansible_interfaces }}"
+      loop: "{{ physical_interfaces.stdout_lines }}"
+
+    - name: "Create virtual network interfaces that have an IP"
+      netbox.netbox.netbox_device_interface:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          device: "{{ inventory_hostname }}"
+          name: "{{ item }}"
+          mac_address: "{{ interface.macaddress|default('unknown') }}"
+          type: virtual
+        state: present
+      vars:
+        interface: >-
+          {{ hostvars[inventory_hostname]["ansible_{}".format(item.replace('-', '_'))] }}
+      delegate_to: 127.0.0.1
+      loop: "{{ansible_interfaces | difference(physical_interfaces.stdout_lines)}}"
       when: interface.type == "ether" and interface.ipv4.address is defined
 
     - name: "Associate IP addresses with network interfaces"

--- a/register-system.yaml
+++ b/register-system.yaml
@@ -44,6 +44,19 @@
       command: find /sys/class/net -type l -not -lname '*virtual*' -printf '%f\n'
       register: physical_interfaces
 
+    - name: "Create a dictionary mapping interface speeds and module name with netbox names"
+      set_fact:
+        speed_map: {
+          '-1': '1000Base-t (1GE)',
+          '1000': '1000Base-t (1GE)',
+          '10000': '10GBase-t (10GE)'
+        }
+        module_map: {
+          'ixgbe': '10GBase-t (10GE)',
+          'tg3': '1000Base-t (1GE)',
+          'sfc': '10GBase-t (10GE)'
+        }
+
     - name: "Calcuate rack and rackpos"
       set_fact:
         rack: "{{ parsed_address[-2] }}"
@@ -134,7 +147,8 @@
           device: "{{ inventory_hostname }}"
           name: "{{ item }}"
           mac_address: "{{ interface.macaddress|default('unknown') }}"
-          type: 10GBase-t (10GE)
+          type: >-
+            {{ speed_map[interface.speed|string] if interface.speed is defined else module_map[interface.module] | default('Other') }}
         state: present
       vars:
         interface: >-


### PR DESCRIPTION
On some of our systems we have NICs where the IP is assigned to a bridge or a
vlan interface. Earlier we were only creating interfaces with an IP assigned
to them which may sometime skip the actual physical NIC.

Here's an example host: https://netbox.apps.ocp-prod.massopen.cloud/dcim/devices/107/interfaces/

This is also important to model the cable connections specially because we want to do this automatically. 

@larsks It would be nice to set the parent of a virtual interface and that should be doable by comparing mac addresses, but I can't figure out how to do that in ansible. But I don't think it's critical to do that. 

