### PR TITLE
Fix the problem where it created duplicate IPMI IP address

### DIFF
--- a/register-system.yaml
+++ b/register-system.yaml
@@ -52,7 +52,8 @@
       register: ipmi_mac_addr
 
     - name: "Get IPMI address"
-      shell: ipmitool lan print |grep "IP Address" | grep -v Source | cut -d ':' -f 2
+      shell: >-
+        ipmitool lan print | awk -F' *: *' '$1 == "IP Address" {print $2}'
       register: ipmi_addr
 
     - name: "Create a dictionary mapping interface speeds and module name with netbox names"


### PR DESCRIPTION
* It was due to a leading space in the IPMI IP address which caused it to
create a duplicate IP.

This is what I am trying to parse
```
[root@kzn-mon1 ~]# ipmitool lan print |grep "IP Address"
IP Address Source       : Static Address
IP Address              : 10.0.19.14
```

