### PR TITLE
Add the rest of the broacade switches

### DIFF
--- a/brocade-switches.yaml
+++ b/brocade-switches.yaml
@@ -11,6 +11,13 @@
       vars:
         ansible_command_timeout: 90
 
+    - name: "Set rbridge id"
+      set_fact:
+        rbridge_id: >-
+          "{{ rbridge_stdout.stdout[0].split(':')[1] | default("1") |trim }}"
+        # need to extract the id from an output like this
+        # "stdout": ["Rbridge-id: 4"]
+
     - name: "Get hostname"
       community.network.nos_command:
         commands: >-
@@ -18,9 +25,6 @@
       register: hostname_stdout
       vars:
         ansible_command_timeout: 90
-        rbridge_id: "{{ rbridge_stdout.stdout[0].split(':')[1]|trim }}"
-        # need to extract the id from an output like this
-        # "stdout": ["Rbridge-id: 4"]
 
     - name: "Get switch model"
       community.network.nos_command:
@@ -40,17 +44,22 @@
 
     - name: "Calcuate rack and rackpos"
       set_fact:
-        rack: "{{ parsed_address[-2] }}"
+        rack: "{{ 'row3/podB/cage' + parsed_address[-2] }}"
         rackpos: "{{ parsed_address[-1] }}"
       vars:
         parsed_address: "{{ ansible_host | split('.') }}"
+      when: rack is not defined
+
+    - name: "Set location to default"
+      set_fact:
+        location: "Row 3 Pod B"
+      when: location is not defined
 
     - name: "Set hostname and other vars"
       set_fact:
         brocade_hostname: "{{ hostname_stdout.stdout[0].split(' ')[2] | trim }}"
         brocade_serial: "{{ serial_stdout.stdout[0].split(':')[1] | trim }}"
         brocade_model: "{{ chassis_stdout.stdout[0].split(':')[1] | trim }}"
-        rbridge_id: "{{ rbridge_stdout.stdout[0].split(':')[1] | trim }}"
 
     - name: "Create the device_type"
       netbox.netbox.netbox_device_type:
@@ -70,11 +79,11 @@
           name: "{{ brocade_hostname }}"
           serial: "{{ brocade_serial }}"
           device_type: "{{ brocade_model }}"
-          rack: "{{ 'row3/podB/cage' + rack }}"
+          rack: "{{ rack }}"
           position: "{{rackpos}}"
           device_role: data_switch
           face: front
-          location: Row 3 Pod B
+          location: "{{ location }}"
           site: MGHPCC
         state: present
       delegate_to: 127.0.0.1

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -129,6 +129,31 @@ all:
               ansible_host: 10.0.17.43
             brocade-19-43:
               ansible_host: 10.0.19.43
+            brocade-e1-101:
+              ansible_host: 10.10.10.64
+              location: Row 4 Pod A
+              rack: row4/podA/cage2
+              rackpos: 41
+            brocade-e1-102:
+              ansible_host: 10.10.10.65
+              location: Row 4 Pod A
+              rack: row4/podA/cage2
+              rackpos: 42
+            brocade-e1-103:
+              ansible_host: 10.10.10.66
+              location: Row 4 Pod A
+              rack: row4/podA/cage2
+              rackpos: 43
+            brocade-e1-104:
+              ansible_host: 10.10.10.67
+              location: Row 4 Pod A
+              rack: row4/podA/cage4
+              rackpos: 43
+            brocade-kumo:
+              ansible_host: 10.0.21.24
+              location: Row 4 Pod A
+              rack: row4/podA/cage21
+              rackpos: 24
           vars:
             ansible_network_os: nos
             ansible_password: "{{ moc_brocade_password }}"


### PR DESCRIPTION
* 4 of those are in engage1 and are in a fabric so they got registered just fine.
* 1 switch is not in a fabric, so required a little adjustment to set a default
rbridge_id.
* also since these switches are not in our kaizen cages where the ipmi address
can be used to calcuate rack and rackposition, I am setting rack and rackpos in
the host file to get those.