### PR TITLE
Register IPMI switches from engage1 and kumo

### DIFF
--- a/group_vars/all/netbox_manufacturers.yaml
+++ b/group_vars/all/netbox_manufacturers.yaml
@@ -1,10 +1,12 @@
 netbox_manufacturers:
+  - Accton
   - Brocade
   - Cisco
   - Dell
   - IBM
   - Generic
   - Intel
+  - Juniper
   - Lenovo
   - Mellanox
   - Quanta

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -205,11 +205,50 @@ all:
               ansible_host: 10.0.17.44
           vars:
             calculate_rack: true
+            model: brocade_icx
+            manufacturer: Brocade
         ibm:
           hosts:
             ipmi-cage19:
               ansible_host: 10.0.19.44
               calculate_rack: true
+          vars:
+            model: RackSwitch G8000
+            manufacturer: IBM
+        cisco_catalyst:
+          hosts:
+            r4-pA-c23-catalyst3650:
+              ansible_host: 10.0.23.41
+              calculate_rack: true
+            egg1-r4pAc04-mgmt:
+              ansible_host: 10.10.10.1
+              rack_number: 4
+              rackpos: 44
+            egg1-r4pAc02-mgmt:
+              ansible_host: 10.10.10.2
+              rack_number: 2
+              rackpos: 44
+          vars:
+            manufacturer: Cisco
+            model: catalyst3650
+            location: Row4/PodA
+        juniper:
+          hosts:
+            e1-r4pAc04-mgmt-02:
+              ansible_host: 10.10.10.5
+              rack_number: 4
+              rackpos: 42
+              location: Row4/PodA
+              manufacturer: Juniper
+              model: ex3300
+        cumulus:
+          hosts:
+            bu-21-25:
+              ansible_host: 10.0.21.25
+              calculate_rack: true
+              manufacturer: Accton
+              model: as4610_54
+              location: Row4/PodA
       vars:
         calculate_rack: false
         location: Row3/PodB

--- a/ipmi-switches.yaml
+++ b/ipmi-switches.yaml
@@ -12,8 +12,8 @@
     - name: "Set device attributes"
       set_fact:
         device_role: "ipmi_switches"
-        manufacturer: "{{ ('brocade_icx' in group_names) | ternary('Brocade', 'IBM') }}"
-        model: "{{ ('brocade_icx' in group_names) | ternary('brocade_icx', 'RackSwitch G8000') }}"
+        manufacturer: "{{ manufacturer }}"
+        model: "{{ model }}"
 
     - name: "Create device role based on ansible group"
       netbox.netbox.netbox_device_role:


### PR DESCRIPTION
It also sets the model and manufacturer in the host file instead of doing the trickery with ternary operator.