### PR TITLE
Register a couple of intel servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 group_vars/all/netbox_creds.yaml
 group_vars/all/switch_creds.yaml
+*.pyc

--- a/group_vars/servers/interface_types.yaml
+++ b/group_vars/servers/interface_types.yaml
@@ -1,0 +1,14 @@
+# a dictionary mapping interface speeds and module name with netbox names
+speed_map: {
+  '-1': 'Other',
+  '1000': '1000Base-t (1GE)',
+  '10000': 'SFP+ (10GE)',
+  '40000': 'QSFP+ (40GE)'
+}
+module_map: {
+  'ixgbe': 'SFP+ (10GE)',
+  'tg3': '1000Base-t (1GE)',
+  'sfc': 'SFP+ (10GE)',
+  'iavf': 'QSFP+ (40GE)',
+  'i40e': 'QSFP+ (40GE)'
+}

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -9,6 +9,18 @@ all:
             ov3.massopen.cloud:
           vars:
             calculate_rack: true
+        misc:
+          hosts:
+            neu-3-30:
+              ansible_host: 172.16.3.30
+              height: 2
+              rack_number: 3
+              rackpos: 30
+            neu-5-30:
+              ansible_host: 172.16.5.30
+              height: 2
+              rack_number: 5
+              rackpos: 30
         production_ceph:
           hosts:
             kzn-mon1:

--- a/register-system.yaml
+++ b/register-system.yaml
@@ -169,7 +169,7 @@
           name: "{{ item }}"
           mac_address: "{{ interface.macaddress|default('unknown') }}"
           type: >-
-            {{ speed_map[interface.speed|string] if interface.speed is defined else module_map[interface.module] | default('Other') }}
+            {{ (module_map[interface.module] if interface.module is defined else speed_map[interface.speed|string]) | default('Other') }}
         state: present
       vars:
         interface: >-

--- a/register-system.yaml
+++ b/register-system.yaml
@@ -232,7 +232,7 @@
     - name: "Create list containing NIC, switchport and switch hostname"
       set_fact:
         connections: "{{ connections + [[nic, switchport, switch]] }}"
-      when: item.rc == 0
+      when: item.rc == 0 and item.stdout != ""  # some systems just didn't report anything in the output
       loop: "{{ sysnames.results }}"
       vars:
         connections: []
@@ -256,6 +256,7 @@
             name: "{{ item[1] }}"
       delegate_to: 127.0.0.1
       loop: "{{ connections }}"
+      when: connections is defined
 
     - name: "Create cable for IPMI interface"
       netbox.netbox.netbox_cable:

--- a/register-system.yaml
+++ b/register-system.yaml
@@ -68,19 +68,6 @@
       vars:
         ipmi_ip: "{{ ipmi_addr.stdout }}"
 
-    - name: "Create a dictionary mapping interface speeds and module name with netbox names"
-      set_fact:
-        speed_map: {
-          '-1': '1000Base-t (1GE)',
-          '1000': '1000Base-t (1GE)',
-          '10000': '10GBase-t (10GE)'
-        }
-        module_map: {
-          'ixgbe': '10GBase-t (10GE)',
-          'tg3': '1000Base-t (1GE)',
-          'sfc': '10GBase-t (10GE)'
-        }
-
     - name: "Set prefixes"
       set_fact:
         prefixes: "{{ netbox_prefixes | map(attribute='prefix') | list }}"

--- a/register-system.yaml
+++ b/register-system.yaml
@@ -46,6 +46,12 @@
     - name: "Get chassis height"
       shell: dmidecode --type chassis |grep Height | cut -d ' ' -f 2
       register: chassis_height
+      when: height is not defined
+
+    - name: "Set height"
+      set_fact:
+        height: "{{ chassis_height.stdout }}"
+      when: height is not defined
 
     - name: "Get IPMI Interface's mac address"
       shell: ipmitool lan print |grep "MAC Address" | awk '{print $4}'
@@ -97,7 +103,7 @@
         data:
           manufacturer: "{{ manufacturer.stdout }}"
           model: "{{ product.stdout }}"
-          u_height: "{{ chassis_height.stdout }}"
+          u_height: "{{ height }}"
         state: present
       delegate_to: 127.0.0.1
 
@@ -118,7 +124,7 @@
         data:
           # https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#defining-different-values-for-true-false-null-ternary
           name: "{{ inventory_hostname }} "
-          serial: "{{ (serial.stdout == '.....') | ternary(uuid.stdout, serial.stdout) }}"
+          serial: "{{ ('....' in serial.stdout) | ternary(uuid.stdout, serial.stdout) }}"
           device_type: "{{ product.stdout }}"
           rack: "{{ rack }}"
           position: "{{rackpos}}"


### PR DESCRIPTION
* For some reason the NICs on these server did not report any lldp information.
So I have added a few checks to ignore such scenarios.

* Allow setting chassis height in hosts file, because dmidecode didn't have that
info for intel systems.

* I also made some changes to the way set interface type:
- moved the dictionary into groupvars
- prefer module type to guess interface type before using speed
- fix paranthesis so it actually defaults to 'Other' instead of failing.
- for speed -1 don't guess 1Gbe, set it to other