### PR TITLE
Register 2 ovirt nfs nodes

### DIFF
--- a/hosts.yaml
+++ b/hosts.yaml
@@ -7,6 +7,10 @@ all:
             ov1.massopen.cloud:
             ov2.massopen.cloud:
             ov3.massopen.cloud:
+            neu-17-40:
+              ansible_host: 172.16.17.40
+            neu-19-40:
+              ansible_host: 172.16.19.40
           vars:
             calculate_rack: true
         misc:


### PR DESCRIPTION
these nodes provide ssd storage for some ovirt guests.

The first nic (p3p1) on both these servers are directly connected to each other but lldptool doesn't read any information on these nics.

