### PR TITLE
Ignore 0.0.0.0 as IPMI address

### DIFF
--- a/register-system.yaml
+++ b/register-system.yaml
@@ -149,6 +149,7 @@
             name: IPMI Interface
             device: "{{ inventory_hostname }}"
         state: present
+      when: ipmi_addr.stdout != '0.0.0.0'
       delegate_to: 127.0.0.1
 
     - name: "Create physical network interfaces"


### PR DESCRIPTION
The intel servers don't report the correct IPMI address.

Where do I get the real IPMI address from then? The hosts file?