### PR TITLE
Add playbook to register chassis devices in netbox

### DIFF
--- a/chassis-devices.yaml
+++ b/chassis-devices.yaml
@@ -1,0 +1,66 @@
+- name: "Register parent chassis devices into netbox"
+  hosts: chassis_devices
+  gather_facts: false
+  tasks:
+
+    - name: "Create the manufacturer"
+      netbox.netbox.netbox_manufacturer:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          name: "{{ manufacturer }}"
+        state: present
+      delegate_to: 127.0.0.1
+
+    - name: "Cacluate and set rack, rack_number and rackpos"
+      include_role:
+        name: calcuate-rack-position
+
+    - name: "Create the device_type"
+      netbox.netbox.netbox_device_type:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          manufacturer: "{{ manufacturer }}"
+          model: "{{ device_type }}"
+          u_height: "{{ height }}"
+          subdevice_role: "parent"
+        state: present
+      delegate_to: 127.0.0.1
+
+    - name: "Create device role"
+      netbox.netbox.netbox_device_role:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          name: "{{ role }}"
+        state: present
+      delegate_to: 127.0.0.1
+
+    - name: "Create the chassis device"
+      netbox.netbox.netbox_device:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          name: "{{ inventory_hostname }} "
+          device_type: "{{ device_type }}"
+          rack: "{{ rack }}"
+          position: "{{rackpos}}"
+          device_role: "{{ role }}"
+          face: front
+          location: "{{ location }}"
+          site: MGHPCC
+        state: present
+      delegate_to: 127.0.0.1
+
+    - name: "Create device bays"
+      netbox.netbox.netbox_device_bay:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          device: "{{ inventory_hostname }}"
+          name: >-
+            Slot {{ item }}
+        state: present
+      loop: "{{ range(1, number_of_bays + 1, 1)|list }}"
+      delegate_to: 127.0.0.1

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -145,9 +145,33 @@ all:
               ansible_host: 172.16.19.12
           vars:
             calculate_rack: true
+        kumo_dell_blades_devices:
+          hosts:
+            bu-23-101:
+              ansible_host: bu-23-101.maas.massopen.cloud
+              parent_device_bay: Slot 1
+          vars:
+            location: Row4/PodA
+            parent_device: kumo_dell_blades
+            rack_number: 23
+            height: 0
       vars:
         ansible_user: root
         location: Row3/PodB
+        calculate_rack: false
+    chassis_devices:
+      hosts:
+        kumo_dell_blades:
+          ansible_host: 10.1.11.5
+          device_type: M1000e
+          number_of_bays: 16
+          location: Row4/PodA
+          height: 8
+          rack_number: 23
+          rackpos: 1
+          manufacturer: Dell Inc.
+          role: misc
+      vars:
         calculate_rack: false
     switches:
       children:

--- a/register-system.yaml
+++ b/register-system.yaml
@@ -98,6 +98,21 @@
           u_height: "{{ height }}"
         state: present
       delegate_to: 127.0.0.1
+      when: height != 0
+
+    - name: "Create the device_type"
+      ignore_errors: true
+      netbox.netbox.netbox_device_type:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          manufacturer: "{{ manufacturer.stdout }}"
+          model: "{{ product.stdout }}"
+          u_height: "{{ height }}"
+          subdevice_role: "child"
+        state: present
+      delegate_to: 127.0.0.1
+      when: height == 0
 
     - name: "Create device role based on ansible group"
       netbox.netbox.netbox_device_role:
@@ -118,14 +133,36 @@
           name: "{{ inventory_hostname }} "
           serial: "{{ ('....' in serial.stdout) | ternary(uuid.stdout, serial.stdout) }}"
           device_type: "{{ product.stdout }}"
-          rack: "{{ rack }}"
-          position: "{{rackpos}}"
           device_role: "{{ group_names[0] }}"
-          face: front
           location: "{{ location }}"
+          rack: "{{ rack }}"
           site: MGHPCC
         state: present
       delegate_to: 127.0.0.1
+
+    - name: "Set device's position within rack"
+      netbox.netbox.netbox_device:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          name: "{{ inventory_hostname }} "
+          position: "{{rackpos}}"
+          face: front
+        state: present
+      delegate_to: 127.0.0.1
+      when: parent_device is not defined
+
+    - name: "Add device to device bay"
+      netbox.netbox.netbox_device_bay:
+        netbox_url: "{{ netbox_url }}"
+        netbox_token: "{{ netbox_token }}"
+        data:
+          installed_device: "{{ inventory_hostname }}"
+          name: "{{ parent_device_bay }}"
+          device: "{{ parent_device }}"
+        state: present
+      delegate_to: 127.0.0.1
+      when: parent_device is defined
 
     - name: "Create IPMI interface for registered device"
       netbox.netbox.netbox_device_interface:


### PR DESCRIPTION
Chassis devices device_type have subdevice_role set to parent. The devices are
then instantiated from that type like a regular device. After that bays or
slots are created on the device.

The devices that go into the chassis need to be instantiated from device_type
with subdevice_role set to "child" and height set to 0. So some
changes are made in register-system.yaml to reflect that. Additionaly, we need
to specify the rack, parent_device and slot/bay name for the child device.