### PR TITLE
Add a role to register servers statically

### DIFF
--- a/group_vars/all/netbox_servers.yaml
+++ b/group_vars/all/netbox_servers.yaml
@@ -1,0 +1,67 @@
+netbox_servers:
+  - site: MGHPCC
+    location: Row3/PodB
+    rack: Row3/PodB/Cage3
+    servers:
+      - name: neu-3-1
+        manufacturer: Dell Inc.
+        model: PowerEdge R620
+        role: BMI
+        rackpos: 1
+        height: 1
+        nics:
+          - name: nic1
+            mac_address: 00:0f:53:22:2d:88
+            switch_hostname: rbr-03
+            switchport: TenGigabitEthernet 3/0/1
+          - name: nic2
+            mac_address: 00:0f:53:22:2d:89
+            switch_hostname: rbr-03
+            switchport: TenGigabitEthernet 3/0/2
+          - name: ipmi
+            switch_hostname: ipmi-cage3
+            switchport: GigabitEthernet 1/1/1
+            type: 1000Base-t (1GE)
+      - name: neu-3-2
+        manufacturer: Dell Inc.
+        model: PowerEdge R620
+        role: BMI
+        rackpos: 2
+        height: 1
+        nics:
+          - name: nic1
+            mac_address: 00:0f:53:22:2e:78
+            switch_hostname: rbr-03
+            switchport: TenGigabitEthernet 3/0/3
+          - name: nic2
+            mac_address: 00:0f:53:22:2d:89
+            switch_hostname: rbr-03
+            switchport: TenGigabitEthernet 3/0/4
+          - name: ipmi
+            switch_hostname: ipmi-cage3
+            switchport: GigabitEthernet 1/1/2
+            type: 1000Base-t (1GE)
+
+  - site: MGHPCC
+    location: Row3/PodB
+    rack: Row3/PodB/Cage5
+    servers:
+      - name: neu-5-24
+        manufacturer: Cisco
+        model: U220
+        role: BMI
+        rackpos: 24
+        height: 1
+        nics:
+          - name: nic1
+            mac_address: 90:e2:ba:82:33:24
+            switch_hostname: rbr-06
+            switchport: TenGigabitEthernet 6/0/8
+          - name: nic2
+            mac_address: 90:e2:ba:82:33:25
+            switch_hostname: rbr-06
+            switchport: TenGigabitEthernet 6/0/7
+          - name: ipmi
+            switch_hostname: ipmi-cage5
+            switchport: GigabitEthernet 1/1/24
+            type: 1000Base-t (1GE)

--- a/register-servers-statically.yaml
+++ b/register-servers-statically.yaml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - static-servers

--- a/roles/static-servers/tasks/main.yaml
+++ b/roles/static-servers/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Register system
+  include_tasks: register_servers.yaml
+  loop: "{{ netbox_servers|subelements('servers') }}"
+  loop_control:
+    label: "{{ item.1.name }}"
+
+- name: Register NICs
+  include_tasks: register_nics.yaml
+  loop: "{{ netbox_servers|subelements('servers') }}"
+  loop_control:
+    label: "{{ item.1.name }}"

--- a/roles/static-servers/tasks/main.yaml
+++ b/roles/static-servers/tasks/main.yaml
@@ -2,10 +2,12 @@
   include_tasks: register_servers.yaml
   loop: "{{ netbox_servers|subelements('servers') }}"
   loop_control:
-    label: "{{ item.1.name }}"
+    loop_var: server
+    label: "{{ server.1.name }}"
 
 - name: Register NICs
   include_tasks: register_nics.yaml
   loop: "{{ netbox_servers|subelements('servers') }}"
   loop_control:
-    label: "{{ item.1.name }}"
+    loop_var: server
+    label: "{{ server.1.name }}"

--- a/roles/static-servers/tasks/register_nics.yaml
+++ b/roles/static-servers/tasks/register_nics.yaml
@@ -12,6 +12,7 @@
   loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic
+    label: "{{ nic.name }}"
 
 - name: Register NIC without mac addresses
   netbox.netbox.netbox_device_interface:
@@ -26,6 +27,7 @@
   loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic
+    label: "{{ nic.name }}"
 
 - name: Create cable to switchport
   netbox.netbox.netbox_cable:
@@ -44,3 +46,4 @@
   loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic
+    label: "{{ nic.name }}"

--- a/roles/static-servers/tasks/register_nics.yaml
+++ b/roles/static-servers/tasks/register_nics.yaml
@@ -1,0 +1,46 @@
+- name: Register NIC
+  netbox.netbox.netbox_device_interface:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      device: "{{ item.1.name }}"
+      name: "{{ nic.name }}"
+      mac_address: "{{ nic.mac_address }}"
+      type: "{{ nic.type | default('SFP+ (10GE)') }}"
+    state: present
+  when: nic.mac_address is defined
+  loop: "{{ item.1.nics }}"
+  loop_control:
+    loop_var: nic
+
+- name: Register NIC without mac addresses
+  netbox.netbox.netbox_device_interface:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      device: "{{ item.1.name }}"
+      name: "{{ nic.name }}"
+      type: "{{ nic.type | default('SFP+ (10GE)') }}"
+    state: present
+  when: nic.mac_address is not defined
+  loop: "{{ item.1.nics }}"
+  loop_control:
+    loop_var: nic
+
+- name: Create cable to switchport
+  netbox.netbox.netbox_cable:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      termination_a_type: dcim.interface
+      termination_a:
+        device: "{{ item.1.name }}"
+        name: "{{ nic.name }}"
+      termination_b_type: dcim.interface
+      termination_b:
+        device: "{{ nic.switch_hostname }}"
+        name: "{{ nic.switchport }}"
+    state: present
+  loop: "{{ item.1.nics }}"
+  loop_control:
+    loop_var: nic

--- a/roles/static-servers/tasks/register_nics.yaml
+++ b/roles/static-servers/tasks/register_nics.yaml
@@ -3,13 +3,13 @@
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      device: "{{ item.1.name }}"
+      device: "{{ server.1.name }}"
       name: "{{ nic.name }}"
       mac_address: "{{ nic.mac_address }}"
       type: "{{ nic.type | default('SFP+ (10GE)') }}"
     state: present
   when: nic.mac_address is defined
-  loop: "{{ item.1.nics }}"
+  loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic
 
@@ -18,12 +18,12 @@
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      device: "{{ item.1.name }}"
+      device: "{{ server.1.name }}"
       name: "{{ nic.name }}"
       type: "{{ nic.type | default('SFP+ (10GE)') }}"
     state: present
   when: nic.mac_address is not defined
-  loop: "{{ item.1.nics }}"
+  loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic
 
@@ -34,13 +34,13 @@
     data:
       termination_a_type: dcim.interface
       termination_a:
-        device: "{{ item.1.name }}"
+        device: "{{ server.1.name }}"
         name: "{{ nic.name }}"
       termination_b_type: dcim.interface
       termination_b:
         device: "{{ nic.switch_hostname }}"
         name: "{{ nic.switchport }}"
     state: present
-  loop: "{{ item.1.nics }}"
+  loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic

--- a/roles/static-servers/tasks/register_nics.yaml
+++ b/roles/static-servers/tasks/register_nics.yaml
@@ -5,25 +5,9 @@
     data:
       device: "{{ server.1.name }}"
       name: "{{ nic.name }}"
-      mac_address: "{{ nic.mac_address }}"
+      mac_address: "{{ nic.mac_address | default(omit) }}"
       type: "{{ nic.type | default('SFP+ (10GE)') }}"
     state: present
-  when: nic.mac_address is defined
-  loop: "{{ server.1.nics }}"
-  loop_control:
-    loop_var: nic
-    label: "{{ nic.name }}"
-
-- name: Register NIC without mac addresses
-  netbox.netbox.netbox_device_interface:
-    netbox_url: "{{ netbox_url }}"
-    netbox_token: "{{ netbox_token }}"
-    data:
-      device: "{{ server.1.name }}"
-      name: "{{ nic.name }}"
-      type: "{{ nic.type | default('SFP+ (10GE)') }}"
-    state: present
-  when: nic.mac_address is not defined
   loop: "{{ server.1.nics }}"
   loop_control:
     loop_var: nic

--- a/roles/static-servers/tasks/register_servers.yaml
+++ b/roles/static-servers/tasks/register_servers.yaml
@@ -1,0 +1,73 @@
+- name: Create manufacturer
+  netbox.netbox.netbox_manufacturer:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      name: "{{ item.1.manufacturer }}"
+    state: present
+
+- name: Create the device_type
+  netbox.netbox.netbox_device_type:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      manufacturer: "{{ item.1.manufacturer }}"
+      model: "{{ item.1.model }}"
+      u_height: "{{ item.1.height }}"
+      subdevice_role: "child"
+    state: present
+  when: item.1.height == 0
+
+- name: Create the device_type
+  netbox.netbox.netbox_device_type:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      manufacturer: "{{ item.1.manufacturer }}"
+      model: "{{ item.1.model }}"
+      u_height: "{{ item.1.height }}"
+    state: present
+  when: item.1.height !=0
+
+- name: Create device role
+  netbox.netbox.netbox_device_role:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      name: "{{ item.1.role }}"
+    state: present
+
+- name: Register system in netbox
+  netbox.netbox.netbox_device:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      name: "{{ item.1.name }}"
+      device_type: "{{ item.1.model }}"
+      location: "{{ item.0.location }}"
+      rack: "{{ item.0.rack }}"
+      device_role: "{{ item.1.role }}"
+      site: "{{ item.0.site }}"
+    state: present
+
+- name: Set device's position within rack
+  netbox.netbox.netbox_device:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      name: "{{ item.1.name }}"
+      position: "{{ item.1.rackpos }}"
+      face: front
+    state: present
+  when: item.1.parent_device is not defined
+
+- name: Add device to bay
+  netbox.netbox.netbox_device_bay:
+    netbox_url: "{{ netbox_url }}"
+    netbox_token: "{{ netbox_token }}"
+    data:
+      installed_device: "{{ item.1.name }}"
+      name: "{{ item.1.parent_device_bay }}"
+      device: "{{ item.1.parent_device }}"
+    state: present
+  when: item.1.parent_device is defined

--- a/roles/static-servers/tasks/register_servers.yaml
+++ b/roles/static-servers/tasks/register_servers.yaml
@@ -3,7 +3,7 @@
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      name: "{{ item.1.manufacturer }}"
+      name: "{{ server.1.manufacturer }}"
     state: present
 
 - name: Create the device_type
@@ -11,30 +11,30 @@
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      manufacturer: "{{ item.1.manufacturer }}"
-      model: "{{ item.1.model }}"
-      u_height: "{{ item.1.height }}"
+      manufacturer: "{{ server.1.manufacturer }}"
+      model: "{{ server.1.model }}"
+      u_height: "{{ server.1.height }}"
       subdevice_role: "child"
     state: present
-  when: item.1.height == 0
+  when: server.1.height == 0
 
 - name: Create the device_type
   netbox.netbox.netbox_device_type:
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      manufacturer: "{{ item.1.manufacturer }}"
-      model: "{{ item.1.model }}"
-      u_height: "{{ item.1.height }}"
+      manufacturer: "{{ server.1.manufacturer }}"
+      model: "{{ server.1.model }}"
+      u_height: "{{ server.1.height }}"
     state: present
-  when: item.1.height !=0
+  when: server.1.height !=0
 
 - name: Create device role
   netbox.netbox.netbox_device_role:
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      name: "{{ item.1.role }}"
+      name: "{{ server.1.role }}"
     state: present
 
 - name: Register system in netbox
@@ -42,12 +42,12 @@
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      name: "{{ item.1.name }}"
-      device_type: "{{ item.1.model }}"
-      location: "{{ item.0.location }}"
-      rack: "{{ item.0.rack }}"
-      device_role: "{{ item.1.role }}"
-      site: "{{ item.0.site }}"
+      name: "{{ server.1.name }}"
+      device_type: "{{ server.1.model }}"
+      location: "{{ server.0.location }}"
+      rack: "{{ server.0.rack }}"
+      device_role: "{{ server.1.role }}"
+      site: "{{ server.0.site }}"
     state: present
 
 - name: Set device's position within rack
@@ -55,19 +55,19 @@
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      name: "{{ item.1.name }}"
-      position: "{{ item.1.rackpos }}"
+      name: "{{ server.1.name }}"
+      position: "{{ server.1.rackpos }}"
       face: front
     state: present
-  when: item.1.parent_device is not defined
+  when: server.1.parent_device is not defined
 
 - name: Add device to bay
   netbox.netbox.netbox_device_bay:
     netbox_url: "{{ netbox_url }}"
     netbox_token: "{{ netbox_token }}"
     data:
-      installed_device: "{{ item.1.name }}"
-      name: "{{ item.1.parent_device_bay }}"
-      device: "{{ item.1.parent_device }}"
+      installed_device: "{{ server.1.name }}"
+      name: "{{ server.1.parent_device_bay }}"
+      device: "{{ server.1.parent_device }}"
     state: present
-  when: item.1.parent_device is defined
+  when: server.1.parent_device is defined


### PR DESCRIPTION
This lets us register systems without SSH access to those machines.

This requires some essential information:
* position of the servers
* manufacturer and type of servers
* NICs and switchports they connect to

Closes #12 